### PR TITLE
copy over ssh host keys

### DIFF
--- a/docs/howtos/secrets.md
+++ b/docs/howtos/secrets.md
@@ -61,3 +61,16 @@ In the above example, replace `"my-super-safe-password"` with your actual
 encryption password, and `my-disk-encryption-password` with the relevant entry
 in your pass password store. Also, ensure to replace `'.#your-host'` and
 `root@yourip` with your actual flake and IP address, respectively.
+
+## Example: Using existing SSH host keys
+
+If the system contains existing trusted `/etc/ssh/ssh_host_*` SSH host keys and
+certificates, `nixos-anywhere` can copy them in case they are necessary during
+installation and system activation.
+
+```
+nixos-anywhere --copy-host-keys --flake '.#your-host' root@yourip
+```
+
+This would copy `/etc/ssh/ssh_host_*` to `/mnt` after kexec but before
+installation, ignoring files that already exist in destination.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,17 +27,28 @@ Options:
   set the flake to install the system from.
 * -i <identity_file>
   selects which SSH private key file to use.
+* -p, --ssh-port <ssh_port>
+  set the ssh port to connect with
+* --ssh-option <ssh_option>
+  set an ssh option
 * -L, --print-build-logs
   print full build logs
 * -s, --store-paths <disko-script> <nixos-system>
   set the store paths to the disko-script and nixos-system directly
   if this is give, flake is not needed
+* -t --tty
+  Force pseudo-terminal allocation in SSH sessions. Use this when you expect e.g.
+  to be asked for password entry during LUKS configuration.
 * --no-reboot
   do not reboot after installation, allowing further customization of the target installation.
-* --kexec <url>
+* --kexec <path>
   use another kexec tarball to bootstrap NixOS
+* --post-kexec-ssh-port <ssh_port>
+  after kexec is executed, use a custom ssh port to connect. Defaults to 22
+* --copy-host-keys
+  copy over existing /etc/ssh/ssh_host_* host keys to the installation
 * --stop-after-disko
-  exit after disko formating, you can then proceed to install manually or some other way
+  exit after disko formatting, you can then proceed to install manually or some other way
 * --extra-files <file...>
   files to copy into the new nixos installation
 * --disk-encryption-keys <remote_path> <local_path>
@@ -53,6 +64,8 @@ Options:
   URL of the source Nix store to copy the nixos and disko closure from
 * --build-on-remote
   build the closure on the remote machine instead of locally and copy-closuring it
+* --vm-test
+  build the system and test the disk configuration inside a VM without installing it to the target.
 ```
 
 ## Explanation of known error messages

--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -470,7 +470,7 @@ if [[ ${copy_host_keys-n} == "y" ]]; then
     # or the destination already exists (e.g. copied with --extra-files).
     if [ ! -e "\$p" -o -e "/mnt/\$p" ]; then
       continue
-    end
+    fi
     cp -a "\$p" "/mnt/\$p"
   done
 fi

--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -123,7 +123,6 @@ while [[ $# -gt 0 ]]; do
     ;;
   --copy-host-keys)
     copy_host_keys=y
-    shift
     ;;
   --debug)
     enable_debug="-x"

--- a/tests/from-nixos.nix
+++ b/tests/from-nixos.nix
@@ -29,6 +29,7 @@
         --kexec /etc/nixos-anywhere/kexec-installer \
         --extra-files /tmp/extra-files \
         --store-paths /etc/nixos-anywhere/disko /etc/nixos-anywhere/system-to-install \
+        --copy-host-keys \
         root@installed >&2
     """)
     try:


### PR DESCRIPTION
nixos-kexec-installer preserves SSH host keys, so should we, to avoid changing host identity.

See also
- https://github.com/nix-community/nixos-images/blob/c4c73bce65306a1e747684dd0d4bcf0ab2779585/nix/kexec-installer/kexec-run.sh#L42C1-L46C1
- https://github.com/nix-community/nixos-images/blob/c4c73bce65306a1e747684dd0d4bcf0ab2779585/nix/installer.nix#L44-L55
