### PR TITLE
nixos-anywhere.sh: recursive umount before zfs export

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -476,6 +476,7 @@ if [[ ${copy_host_keys-n} == "y" ]]; then
 fi
 nixos-install --no-root-passwd --no-channel-copy --system "$nixos_system"
 if command -v zpool >/dev/null; then
+  umount --recursive /mnt # needed to then export zpool
   zpool export -a || : # we always want to export the zfs pools so people can boot from it without force import
 fi
 # We will reboot in background so we can cleanly finish the script before the hosts go down.


### PR DESCRIPTION
fixes zpool export error when some FS are mounted under some ZFS mount.

When ZFS is used as the root filesystem, other FS will be mounted under it, like at `/mnt/boot`.
`zpool export -a` will try to unmount `/mnt` and fail.
This will then prevent the installed system from booting without forcing the import with `zfs_force` in the kernel command line.