### PR TITLE
fix: Set BatchMode for ssh-copy-id

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -288,6 +288,7 @@ step Uploading install SSH keys
 until
   ssh-copy-id \
     -i "$ssh_key_dir"/nixos-anywhere.pub \
+    -o BatchMode=yes \
     -o ConnectTimeout=10 \
     -o UserKnownHostsFile=/dev/null \
     -o StrictHostKeyChecking=no \


### PR DESCRIPTION
`ssh-copy-id` can hang indefinitely at the SSH password prompt if Server is configured to allow KeyboardAuthentication and PubKeyAuth fails.

SSH BatchMode instructs the ssh client to disable all interactive user prompts like password and host key confirmation.

Using the terraform module without `BatchMode` can result in a terraform apply run hanging "forever" at the password prompt.  With BatchMode enabled the terraform apply run fails correctly.