### PR TITLE
terraform/install: support `build_on_remote`

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -415,15 +415,20 @@ if [[ ${build_on_remote-n} == "y" ]]; then
   pubkey=$(echo "$pubkey" | sed -e 's/^[^ ]* //' | base64 -w0)
 fi
 
-if [[ -z ${disko_script-} ]] && [[ ${build_on_remote-n} == "y" ]]; then
+if [[ -n ${disko_script-} ]]; then
+  nix_copy --to "ssh://$ssh_connection" "$disko_script"
+elif [[ ${build_on_remote-n} == "y" ]]; then
   step Building disko script
+  # We need to do a nix copy first because nix build doesn't have --no-check-sigs
+  nix_copy --to "ssh-ng://$ssh_connection" "${flake}#nixosConfigurations.\"${flakeAttr}\".config.system.build.diskoScript" \
+    --derivation --no-check-sigs
   disko_script=$(
     nix_build "${flake}#nixosConfigurations.\"${flakeAttr}\".config.system.build.diskoScript" \
-      --builders "ssh://$ssh_connection $is_arch-linux $ssh_key_dir/nixos-anywhere - - - - $pubkey "
+      --eval-store auto --store "ssh-ng://$ssh_connection?ssh-key=$ssh_key_dir/nixos-anywhere"
   )
 fi
+
 step Formatting hard drive with disko
-nix_copy --to "ssh://$ssh_connection" "$disko_script"
 ssh_ "$disko_script"
 
 if [[ ${stop_after_disko-n} == "y" ]]; then
@@ -433,15 +438,19 @@ if [[ ${stop_after_disko-n} == "y" ]]; then
   exit 0
 fi
 
-if [[ -z ${nixos_system-} ]] && [[ ${build_on_remote-n} == "y" ]]; then
+if [[ -n ${nixos_system-} ]]; then
+  step Uploading the system closure
+  nix_copy --to "ssh://$ssh_connection?remote-store=local?root=/mnt" "$nixos_system"
+elif [[ ${build_on_remote-n} == "y" ]]; then
   step Building the system closure
+  # We need to do a nix copy first because nix build doesn't have --no-check-sigs
+  nix_copy --to "ssh-ng://$ssh_connection?remote-store=local?root=/mnt" "${flake}#nixosConfigurations.\"${flakeAttr}\".config.system.build.toplevel" \
+    --derivation --no-check-sigs
   nixos_system=$(
     nix_build "${flake}#nixosConfigurations.\"${flakeAttr}\".config.system.build.toplevel" \
-      --builders "ssh://$ssh_connection?remote-store=local?root=/mnt $is_arch-linux $ssh_key_dir/nixos-anywhere - - - - $pubkey "
+      --eval-store auto --store "ssh-ng://$ssh_connection?ssh-key=$ssh_key_dir/nixos-anywhere&remote-store=local?root=/mnt"
   )
 fi
-step Uploading the system closure
-nix_copy --to "ssh://$ssh_connection?remote-store=local?root=/mnt" "$nixos_system"
 
 if [[ -n ${extra_files-} ]]; then
   if [[ -d $extra_files ]]; then

--- a/terraform/install/main.tf
+++ b/terraform/install/main.tf
@@ -18,6 +18,8 @@ resource "null_resource" "nixos-remote" {
       target_host = var.target_host
       extra_files_script = var.extra_files_script
       no_reboot = var.no_reboot
+      build_on_remote = var.build_on_remote
+      flake = var.flake
     }, var.extra_environment)
     command = "${path.module}/run-nixos-anywhere.sh ${join(" ", local.disk_encryption_key_scripts)}"
     quiet   = var.debug_logging

--- a/terraform/install/run-nixos-anywhere.sh
+++ b/terraform/install/run-nixos-anywhere.sh
@@ -17,7 +17,14 @@ fi
 if [[ ${no_reboot-} == "true" ]]; then
   args+=("--no-reboot")
 fi
-args+=("--store-paths" "${nixos_partitioner}" "${nixos_system}")
+if [[ ${build_on_remote-} == "true" ]]; then
+  args+=("--build-on-remote")
+fi
+if [[ -n ${flake-} ]]; then
+  args+=("--flake" "${flake}")
+else
+  args+=("--store-paths" "${nixos_partitioner}" "${nixos_system}")
+fi
 
 tmpdir=$(mktemp -d)
 cleanup() {

--- a/terraform/install/variables.tf
+++ b/terraform/install/variables.tf
@@ -8,12 +8,14 @@ variable "kexec_tarball_url" {
 variable "nixos_partitioner" {
   type        = string
   description = "nixos partitioner and mount script"
+  default     = ""
 }
 
 # To make this re-usable we maybe should accept a store path here?
 variable "nixos_system" {
   type        = string
   description = "The nixos system to deploy"
+  default     = ""
 }
 
 variable "target_host" {
@@ -82,4 +84,16 @@ variable "no_reboot" {
   type        = bool
   description = "Do not reboot the machine after installation"
   default     = false
+}
+
+variable "build_on_remote" {
+  type        = bool
+  description = "Build the closure on the remote machine instead of building it locally and copying it over"
+  default     = false
+}
+
+variable "flake" {
+  type        = string
+  description = "The flake to install the system from"
+  default     = ""
 }

--- a/tests/flake-module.nix
+++ b/tests/flake-module.nix
@@ -18,5 +18,7 @@
       from-nixos-stable = import ./from-nixos.nix testInputsStable;
       from-nixos-with-sudo = import ./from-nixos-with-sudo.nix testInputsUnstable;
       from-nixos-with-sudo-stable = import ./from-nixos-with-sudo.nix testInputsStable;
+
+      from-nixos-build-on-remote = import ./from-nixos-build-on-remote.nix testInputsUnstable;
     });
 }

--- a/tests/from-nixos-build-on-remote.nix
+++ b/tests/from-nixos-build-on-remote.nix
@@ -1,0 +1,43 @@
+(import ./lib/test-base.nix) {
+  name = "from-nixos-build-on-remote";
+  nodes = {
+    installer = ./modules/installer.nix;
+    installed = {
+      services.openssh.enable = true;
+      virtualisation.memorySize = 1512;
+
+      users.users.root.openssh.authorizedKeys.keyFiles = [ ./modules/ssh-keys/ssh.pub ];
+    };
+  };
+  testScript = ''
+    def create_test_machine(oldmachine=None, args={}): # taken from <nixpkgs/nixos/tests/installer.nix>
+        machine = create_machine({
+          "qemuFlags":
+            '-cpu max -m 1024 -virtfs local,path=/nix/store,security_model=none,mount_tag=nix-store,'
+            f' -drive file={oldmachine.state_dir}/installed.qcow2,id=drive1,if=none,index=1,werror=report'
+            f' -device virtio-blk-pci,drive=drive1',
+        } | args)
+        driver.machines.append(machine)
+        return machine
+    start_all()
+
+    installer.succeed("""
+      nixos-anywhere \
+        -i /root/.ssh/install_key \
+        --debug \
+        --build-on-remote \
+        --kexec /etc/nixos-anywhere/kexec-installer \
+        --store-paths /etc/nixos-anywhere/disko /etc/nixos-anywhere/system-to-install \
+        root@installed >&2
+    """)
+    try:
+      installed.shutdown()
+    except BrokenPipeError:
+      # qemu has already exited
+      pass
+    new_machine = create_test_machine(oldmachine=installed, args={ "name": "after_install" })
+    new_machine.start()
+    hostname = new_machine.succeed("hostname").strip()
+    assert "nixos-anywhere" == hostname, f"'nixos-anywhere' != '{hostname}'"
+  '';
+}


### PR DESCRIPTION
Remove the trusted user requirement for `--build-on-remote` by using `--store` instead of `--builders`

This is very useful for cross architecture deploys especially without any remote builders configured