### PR TITLE
Fix container detection

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -314,7 +314,7 @@ is_arch=\$(uname -m)
 is_kexec=\$(if test -f /etc/is_kexec; then echo "y"; else echo "n"; fi)
 is_nixos=\$is_nixos
 is_installer=\$(if [[ "\$is_nixos" == "y" ]] && grep -q VARIANT_ID=installer /etc/os-release; then echo "y"; else echo "n"; fi)
-is_container=\$(has systemd-detect-virt && systemd-detect-virt --container || echo "none")
+is_container=\$(if [[ "\$(has systemd-detect-virt)" == "y" ]]; then systemd-detect-virt --container; else echo "none"; fi)
 has_tar=\$(has tar)
 has_sudo=\$(has sudo)
 has_wget=\$(has wget)


### PR DESCRIPTION
When systemd-detect-virt exists and we aren't in a container, is_container contains `y none none` instead of `none`.
This causes nixos-anywhere to warn `WARNING: This script does not support running from a 'y' container. kexec will likely not work` even though we aren't in a container.

1. has outputs y/n to stdout which we need to remove
2. `systemd-detect-virt --container` returns non-zero when we aren't in a container, use if then else instead of && || to prevent duplicating `none` in is_container variable

Tested running against a stock debian 12 with bash as login shell