### PR TITLE
feat(terraform): re-export store path result from all-in-one module

### DIFF
--- a/terraform/all-in-one.md
+++ b/terraform/all-in-one.md
@@ -1,4 +1,4 @@
-main# All-in-one
+# All-in-one
 
 Combines the install and nixos-rebuild module in one interface to install NixOS
 with nixos-anywhere and than keep it up-to-date with nixos-rebuild.

--- a/terraform/all-in-one.md
+++ b/terraform/all-in-one.md
@@ -1,4 +1,4 @@
-# All-in-one
+main# All-in-one
 
 Combines the install and nixos-rebuild module in one interface to install NixOS
 with nixos-anywhere and than keep it up-to-date with nixos-rebuild.
@@ -122,6 +122,8 @@ No resources.
 
 ## Outputs
 
-No outputs.
+| Name                                                  | Description                                                |
+| ----------------------------------------------------- | ---------------------------------------------------------- |
+| <a name="output_result"></a> [result](#output_result) | The resulting store path from building `nixos_system_attr` |
 
 <!-- END_TF_DOCS -->

--- a/terraform/all-in-one/main.tf
+++ b/terraform/all-in-one/main.tf
@@ -46,3 +46,7 @@ module "nixos-rebuild" {
   target_host = var.target_host
   target_user = var.target_user
 }
+
+output "result" {
+  value = module.system-build.result
+}


### PR DESCRIPTION
I need to access the store path while using `all-in-one` Terraform module but it's only exported from the `nix-build` TF module.