### PR TITLE
Allow installs through terraform to work on different ports

### DIFF
--- a/terraform/all-in-one/main.tf
+++ b/terraform/all-in-one/main.tf
@@ -45,6 +45,7 @@ module "nixos-rebuild" {
   ssh_private_key = var.deployment_ssh_key
   target_host = var.target_host
   target_user = var.target_user
+  target_port = var.target_port
 }
 
 output "result" {

--- a/terraform/install/main.tf
+++ b/terraform/install/main.tf
@@ -16,6 +16,7 @@ resource "null_resource" "nixos-remote" {
       nixos_system = var.nixos_system
       target_user = var.target_user
       target_host = var.target_host
+      target_port = var.target_port
       extra_files_script = var.extra_files_script
       no_reboot = var.no_reboot
       build_on_remote = var.build_on_remote

--- a/terraform/install/run-nixos-anywhere.sh
+++ b/terraform/install/run-nixos-anywhere.sh
@@ -48,6 +48,8 @@ if [[ ${extra_files_script-} != "" ]]; then
   popd
   args+=("--extra-files" "${tmpdir}/extra-files")
 fi
+
+args+=("-p" "${target_port}")
 args+=("${target_user}@${target_host}")
 
 keyIdx=0


### PR DESCRIPTION
should fix issues with installing to ports other than the default