### PR TITLE
Detect IPv6 automatically, Rewrite kexec url

### DIFF
--- a/src/get-facts.sh
+++ b/src/get-facts.sh
@@ -11,6 +11,7 @@ is_kexec=$(if test -f /etc/is_kexec; then echo "y"; else echo "n"; fi)
 is_nixos=$is_nixos
 is_installer=$(if [ "$is_nixos" = "y" ] && grep -q VARIANT_ID=installer /etc/os-release; then echo "y"; else echo "n"; fi)
 is_container=$(if [ "$(has systemd-detect-virt)" = "y" ]; then systemd-detect-virt --container; else echo "none"; fi)
+has_ipv6_only=$(if [[ "$(has ip)" == "n" ]] || ip r g 1 >/dev/null 2>/dev/null || ! ip -6 r g :: >/dev/null 2>/dev/null; then echo "n"; else echo "y"; fi)
 has_tar=$(has tar)
 has_sudo=$(has sudo)
 has_doas=$(has doas)

--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -18,7 +18,7 @@ Options:
 * -L, --print-build-logs
   print full build logs
 * --env-password
-  set a password used by ssh-copy-id, the password should be set by 
+  set a password used by ssh-copy-id, the password should be set by
   the environment variable SSH_PASS
 * -s, --store-paths <disko-script> <nixos-system>
   set the store paths to the disko-script and nixos-system directly
@@ -378,6 +378,11 @@ set -efu ${enable_debug}
 $maybe_sudo rm -rf /root/kexec
 $maybe_sudo mkdir -p /root/kexec
 SSH
+
+  # no way to reach global ipv4 destinations, use gh-v6.com automatically if github url
+  if [[ ${has_ipv6_only-n} == "y" ]] && [[ $kexec_url == "https://github.com/"* ]]; then
+    kexec_url=${kexec_url/"github.com"/"gh-v6.com"}
+  fi
 
   if [[ -f $kexec_url ]]; then
     ssh_ "${maybe_sudo} tar -C /root/kexec -xvzf-" <"$kexec_url"


### PR DESCRIPTION
This uses ip r g 1.1.1.1 to test if there's any route to an IPv4 internet host

If that fails and the url is a github.com one it will change github.com to gh-v6.com,
as specified in the documentation

This saves the user from an extra manual step and makes nixos-anywhere better

The fallback behaviour if the ip binary cannot be found is to just assume ipv4 connectivity. I can invert that if wanted.