### PR TITLE
feat: add copy-password

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -106,6 +106,12 @@ below.
 6. On the target machine, make sure you have access as root via ssh by adding
    your SSH key to the file `authorized_keys` in the directory `/root/.ssh`
 
+   Optionally, bootstrapping can also be performed through password login. For
+   example through the `image-installer-*` provided by
+   `nix-community/nixos-images`. Assign your password to the `SSH_PASS`
+   environment variable and specify `--env-password` as an additional command
+   line option. This will provide `ssh-copy-id` with the required password.
+
 7. (Optional) Test your nixos and disko configuration:
 
    The following command will automatically test your nixos configuration and

--- a/src/default.nix
+++ b/src/default.nix
@@ -10,6 +10,7 @@
 , gawk
 , findutils
 , gnused
+, sshpass
 , terraform-docs
 , lib
 , makeWrapper
@@ -26,6 +27,7 @@ let
     gawk
     findutils
     gnused # needed by ssh-copy-id
+    sshpass # used to provide password for ssh-copy-id
     rsync # used to upload extra-files
   ];
 in

--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -17,6 +17,9 @@ Options:
   set an ssh option
 * -L, --print-build-logs
   print full build logs
+* --env-password
+  set a password used by ssh-copy-id, the password should be set by 
+  the environment variable SSH_PASS
 * -s, --store-paths <disko-script> <nixos-system>
   set the store paths to the disko-script and nixos-system directly
   if this is give, flake is not needed
@@ -162,6 +165,9 @@ while [[ $# -gt 0 ]]; do
   --build-on-remote)
     build_on_remote=y
     ;;
+  --env-password)
+    env_password=y
+    ;;
   --vm-test)
     vm_test=y
     ;;
@@ -288,14 +294,27 @@ ssh_port=$(echo "$ssh_settings" | awk '/^port / { print $2 }')
 
 step Uploading install SSH keys
 until
-  ssh-copy-id \
-    -i "$ssh_key_dir"/nixos-anywhere.pub \
-    -o ConnectTimeout=10 \
-    -o UserKnownHostsFile=/dev/null \
-    -o StrictHostKeyChecking=no \
-    "${ssh_copy_id_args[@]}" \
-    "${ssh_args[@]}" \
-    "$ssh_connection"
+  if [[ -n ${env_password-} ]]; then
+    sshpass -e \
+      ssh-copy-id \
+      -i "$ssh_key_dir"/nixos-anywhere.pub \
+      -o ConnectTimeout=10 \
+      -o UserKnownHostsFile=/dev/null \
+      -o IdentitiesOnly=yes \
+      -o StrictHostKeyChecking=no \
+      "${ssh_copy_id_args[@]}" \
+      "${ssh_args[@]}" \
+      "$ssh_connection"
+  else
+    ssh-copy-id \
+      -i "$ssh_key_dir"/nixos-anywhere.pub \
+      -o ConnectTimeout=10 \
+      -o UserKnownHostsFile=/dev/null \
+      -o StrictHostKeyChecking=no \
+      "${ssh_copy_id_args[@]}" \
+      "${ssh_args[@]}" \
+      "$ssh_connection"
+  fi
 do
   sleep 3
 done


### PR DESCRIPTION
Allow setting the bootstrap password on invocation of `nixos-anywhere`.

This makes use of the `sshpass` program, to provide `ssh-copy-id` with the password.

The `runtimeDeps` change in the following way:

sshpass: ∅ → 1.10, +29.5 KiB

Improves the usage especially together with the iso image installers of `nixos-images`.