### PR TITLE
Don't fail if .ssh/authorized_keys is missing

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -419,7 +419,8 @@ fi
 # Installation will fail if non-root user is used for installer.
 # Switch to root user by copying authorized_keys.
 if [[ ${is_installer-n} == "y" ]] && [[ ${ssh_user} != "root" ]]; then
-  ssh_ "${maybe_sudo} mkdir -p /root/.ssh; ${maybe_sudo} cp ~/.ssh/authorized_keys /root/.ssh"
+  # Allow copy to fail if authorized_keys does not exist, like if using /etc/ssh/authorized_keys.d/
+  ssh_ "${maybe_sudo} mkdir -p /root/.ssh; ${maybe_sudo} cp ~/.ssh/authorized_keys /root/.ssh || true"
   ssh_connection="root@${ssh_host}"
 fi
 


### PR DESCRIPTION
I ran into this issue recently where the target system was using /etc/ssh.d/authorized_keys.d/ and had no ~/.ssh/authorized_keys file, and so this line would fail. But it was also already configured to allow root access via /etc/ssh.d/authorized_keys.d/, so by not hard failing on the inability to copy ~/.ssh/authorized_keys the install would succeed. This change simply allows it to continue if the copy fails, and so failure (if it exists) will transition to inability to login as root.