### PR TITLE
docs: simplify non-flakes instructions

### DIFF
--- a/docs/howtos/use-without-flakes.md
+++ b/docs/howtos/use-without-flakes.md
@@ -8,45 +8,75 @@ in your NixOS configuration and define disko devices as described in the
 Let's assume that your NixOS configuration lives in `configuration.nix` and your
 target machine is called `machine`:
 
+## 1. Download your favourite disk layout:
+
+See https://github.com/nix-community/disko-templates/ for more examples:
+
+The example below will work with both UEFI and BIOS-based systems.
+
+```bash
+curl https://raw.githubusercontent.com/nix-community/disko-templates/main/single-disk-ext4/disko-config.nix > ./disko-config.nix
+```
+
+## 2. Get a hardware-configuration.nix from on the target machine
+
+- **Option 1**: If NixOS is not installed, boot into an installer without first
+  installing NixOS.
+- **Option 2**: Use the kexec tarball method, as described
+  [here](https://github.com/nix-community/nixos-images#kexec-tarballs).
+
+- **Generate Configuration**: Run the following command on the target machine:
+
+  ```bash
+  nixos-generate-config --no-filesystems --dir /tmp/config
+  ```
+
+This creates the necessary configuration files under `/tmp/config/`. Copy
+`/tmp/config/nixos/hardware-configuration.nix` to your local machine into the
+same directory as `disko-config.nix`.
+
+## 3. Set NixOS version to use
+
 ```nix
-# configuration.nix
-{
-  sources ? {
-    nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-24.05";
-    disko = fetchTarball "https://github.com/nix-community/disko/tarball/v1.6.1";
-  },
-  system ? builtins.currentSystem,
-  pkgs ? import sources.nixpkgs { inherit system; config = {}; overlays = []; },
-}:
-rec {
-  machine = pkgs.nixos config;
-  config = { config, pkgs, ... }: {
-    system.stateVersion = "24.05";
-    imports = [
-      "${sources.disko}/module.nix"
-      "${sources.disko}/example/hybrid.nix"
-    ];
-    disko.devices.disk.main.device = "/dev/sda";
-    boot.loader.systemd-boot.enable = true;
-  };
+# default.nix
+let
+  # replace nixos-24.05 with your preferred nixos version or revision from here: https://status.nixos.org/
+  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-24.05.tar.gz";
+in
+import (nixpkgs + "/nixos/lib/eval-config.nix") {
+  modules = [ ./configuration.nix ];
 }
 ```
 
-Generate the disk formatting script:
+## 4. Write a NixOS configuration
 
-```bash
-disko=$(nix-build configuration.nix -A machine.config.system.build.disko' --no-out-path)
+```nix
+# configuration.nix
+{
+  imports = [
+   "${fetchTarball "https://github.com/nix-community/disko/tarball/master"}/module.nix"
+    ./disko-config.nix
+    ./hardware-configuration.nix
+  ];
+  # Replace this with the system of the installation target you want to install!!!
+  disko.devices.disk.main.device = "/dev/sda";
+
+  # Set this to the NixOS version that you have set in the previous step.
+  # For more information, see `man configuration.nix` or https://nixos.org/manual/nixos/stable/options#opt-system.stateVersion .
+  system.stateVersion = "24.05";
+}
 ```
 
-Generate the store path that includes all the software and configurations for
-the NixOS system:
+## 5. Build and deploy with nixos-anywhere
 
-```bash
-nixos=$(nix-build configuration.nix -A machine.config.system.build.toplevel' --no-out-path)
-```
+Your current directory now should contain the following files from the previous
+step:
+
+- `configuration.nix`, `default.nix`, `disko-config.nix` and
+  `hardware-configuration.nix`
 
 Run `nixos-anywhere` as follows:
 
 ```bash
-nixos-anywhere --store-paths $disko $nixos root@machine
+nixos-anywhere --store-paths $(nix-build -A config.system.build.disko -A config.system.build.toplevel --no-out-link) root@machine
 ```

--- a/docs/howtos/use-without-flakes.md
+++ b/docs/howtos/use-without-flakes.md
@@ -6,16 +6,29 @@ in your NixOS configuration and define disko devices as described in the
 [examples](https://github.com/nix-community/disko/tree/master/example).
 
 Let's assume that your NixOS configuration lives in `configuration.nix` and your
-target machine is called `machine`.
+target machine is called `machine`:
 
 ```nix
 # configuration.nix
 {
-  pkgs ? import (fetchTarball channel:nixos-24.05) {};
+  sources ? {
+    nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-24.05";
+    disko = fetchTarball "https://github.com/nix-community/disko/tarball/v1.6.1";
+  },
+  system ? builtins.currentSystem,
+  pkgs ? import sources.nixpkgs { inherit system; config = {}; overlays = []; },
 }:
-{
-  config = { config, pkgs, ... }: { /* ... */ };
+rec {
   machine = pkgs.nixos config;
+  config = { config, pkgs, ... }: {
+    system.stateVersion = "24.05";
+    imports = [
+      "${sources.disko}/module.nix"
+      "${sources.disko}/example/hybrid.nix"
+    ];
+    disko.devices.disk.main.device = "/dev/sda";
+    boot.loader.systemd-boot.enable = true;
+  };
 }
 ```
 

--- a/docs/howtos/use-without-flakes.md
+++ b/docs/howtos/use-without-flakes.md
@@ -1,49 +1,39 @@
 # Use without flakes
 
-While `nixos-anywhere` is designed to work optimally with Nix Flakes, it also
-supports the traditional approach without flakes. This document outlines how to
-use `nixos-anywhere` without relying on flakes. You will need to
-[import the disko nixos module](https://github.com/nix-community/disko/blob/master/docs/HowTo.md#installing-nixos-module)
+First,
+[import the disko NixOS module](https://github.com/nix-community/disko/blob/master/docs/HowTo.md#installing-nixos-module)
 in your NixOS configuration and define disko devices as described in the
 [examples](https://github.com/nix-community/disko/tree/master/example).
 
-## Generate Required Store Paths
+Let's assume that your NixOS configuration lives in `configuration.nix` and your
+target machine is called `machine`.
 
-Before you can use `nixos-anywhere` without flakes, you'll need to manually
-generate the paths for the NixOS system toplevel and disk image. The paths are
-generated using `nix-build` and are necessary for executing `nixos-anywhere`.
-
-### Generating Disk Image without Dependencies:
-
-To generate the disk image without dependencies, execute:
-
-```bash
-nix-build -I nixos-config=/etc/nixos/configuration.nix -E '(import <nixpkgs/nixos> {}).config.system.build.diskoNoDeps'
+```nix
+# configuration.nix
+{
+  pkgs ? import (fetchTarball channel:nixos-24.05) {};
+}:
+{
+  config = { config, pkgs, ... }: { /* ... */ };
+  machine = pkgs.nixos config;
+}
 ```
 
-This will output a script path in `/nix/store` that will format your disk. Make
-note of this path for later use.
-
-### Generating NixOS System Toplevel:
-
-Execute the following command to generate the store path for the NixOS system
-toplevel:
+Generate the disk formatting script:
 
 ```bash
-nix-build -I nixos-config=/etc/nixos/configuration.nix -E '(import <nixpkgs/nixos> {}).config.system.build.toplevel'
+disko=$(nix-build configuration.nix -A machine.config.system.build.disko' --no-out-path)
 ```
 
-This will output a path in `/nix/store` that corresponds to the system toplevel,
-which includes all the software and configurations for the system. Keep this
-path handy as well.
-
-## Running NixOS-Anywhere
-
-With both paths in hand, you can execute `nixos-anywhere` as follows:
+Generate the store path that includes all the software and configurations for
+the NixOS system:
 
 ```bash
-nixos-anywhere --store-paths /nix/store/[your-disk-image-path] /nix/store/[your-toplevel-path]
+nixos=$(nix-build configuration.nix -A machine.config.system.build.toplevel' --no-out-path)
 ```
 
-Replace `[your-disk-image-path]` and `[your-toplevel-path]` with the
-corresponding store paths you generated earlier.
+Run `nixos-anywhere` as follows:
+
+```bash
+nixos-anywhere --store-paths $disko $nixos root@machine
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -59,7 +59,7 @@ below.
 - **Generate Configuration**: Run the following command on the target machine:
 
   ```bash
-  nixos-generate-config --no-filesystems --root /mnt
+  nixos-generate-config --no-filesystems --dir /mnt
   ```
 
   This creates the necessary configuration files under `/mnt/etc/nixos/`, which


### PR DESCRIPTION
I had a hard time figuring out what to do, and all that's required is actually this.

most importantly, using the `noDeps` variant doesn't work because, obviously, it doesn't ship the dependencies