### PR TITLE
terraform/install: deal with symlinks better

### DIFF
--- a/terraform/install/run-nixos-anywhere.sh
+++ b/terraform/install/run-nixos-anywhere.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+SCRIPT_DIR="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 args=()
 
 if [[ ${debug_logging-} == "true" ]]; then


### PR DESCRIPTION
When used with `terranix`, if `SCRIPT_DIR` isn't fully resolved, Nix attempts to look for `flake.nix` in the wrong directory.

```
/nix/store/2djy58syb5jwyc0lbvmsradnimz77gqn-source
├── modules
│   ├── install -> /nix/store/3r4pxmns5pdcal30iwj0sg04iw8ghiqf-source/terraform/install
│   └── modules.json
├── plugin_path
└── providers
    └── ...
```

```
module.install.null_resource.nixos-remote (local-exec): error: path '/nix/store/2djy58syb5jwyc0lbvmsradnimz77gqn-source/flake.nix' does not exist
╷
│ Error: local-exec provisioner error
│ 
│   with module.install.null_resource.nixos-remote,
│   on .terraform/modules/install/main.tf line 9, in resource "null_resource" "nixos-remote":
│    9:   provisioner "local-exec" {
│ 
│ Error running command '.terraform/modules/install/run-nixos-anywhere.sh ': exit status 1. Output: /tmp/tmp.6oCtqrKCsq/extra-files ~/temp
│ ~/temp
│ error: path '/nix/store/2djy58syb5jwyc0lbvmsradnimz77gqn-source/flake.nix' does not exist
```