### PR TITLE
fix incorrect user explanation

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -521,7 +521,7 @@ nohup sh -c '${maybe_reboot}' >/dev/null &
 SSH
 
 if [[ -n ${maybe_reboot} ]]; then
-  step Waiting for the machine to become reachable again
+  step Waiting for the machine to become unreachable due to reboot
   while timeout_ssh_ -- exit 0; do sleep 1; done
 fi
 


### PR DESCRIPTION
Hello!

I just used nixos-anywhere for the first time. It went fairly smoothly except for this surprise this at the end of my logs:

```
### Waiting for the machine to become reachable again ###
ssh: connect to host 192.168.1.146 port 22: Connection refused
### Done! ###
```

It... "wait[ed] for the machine to become reachable again" only to stop immediately on a connection refused? Huh?

I looked through the nixos-anywhere source and it looks like this message is actually inverted -- we are waiting for the machine to become <i>un</i>reachable. I am deducing that from the fact that a previous step in the script that uses the same wait loop but says we are waiting for unreachability:

https://github.com/nix-community/nixos-anywhere/blob/f99d120b3788a286989db4e592a698f5d310d2f6/src/nixos-anywhere.sh#L417-L418

There also used to be a comment here that said <i>un</i>reachable before the user message that says reachable was added in 099790802d16631fd263e55e57aedff2d0c4302d:

<img width="432" alt="Screenshot 2024-07-06 at 3 04 11 PM" src="https://github.com/nix-community/nixos-anywhere/assets/5741620/146b618e-5bb3-41af-ba90-b099c880e066">

This PR changes the message back to say <i>un</i>reachable.