### PR TITLE
docs/nix-path.md: fix input parameter in example

### DIFF
--- a/docs/howtos/nix-path.md
+++ b/docs/howtos/nix-path.md
@@ -23,7 +23,7 @@ configuration instead:
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   # ... other inputs
 
-  outputs = { nixpkgs, ... }:
+  outputs = inputs@{ nixpkgs, ... }:
     {
       nixosConfigurations.yoursystem = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux"; # adapt to your actual system


### PR DESCRIPTION
otherwise this example doesn't work as-is