### PR TITLE
Add option --ssh-store-settings

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,6 +29,8 @@ Options:
   use another kexec tarball to bootstrap NixOS
 * --kexec-extra-flags
   extra flags to add into the call to kexec, e.g. "--no-sync"
+* --ssh-store-setting <key> <value>
+  ssh store settings appended to the store URI, e.g. "compress true". <value> needs to be URI encoded.
 * --post-kexec-ssh-port <ssh_port>
   after kexec is executed, use a custom ssh port to connect. Defaults to 22
 * --copy-host-keys

--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -638,7 +638,7 @@ runDisko() {
     # If we don't use ssh-ng here, we get `error: operation 'getFSAccessor' is not supported by store`
     diskoScript=$(
       nixBuild "${flake}#${flakeAttr}.system.build.${diskoMode}Script" \
-        --eval-store auto --store "ssh-ng://$sshConnection?ssh-key=$sshKeyDir/nixos-anywhere"
+        --eval-store auto --store "ssh-ng://$sshConnection?ssh-key=$sshKeyDir%2Fnixos-anywhere"
     )
   fi
 
@@ -650,17 +650,17 @@ nixosInstall() {
   local nixosSystem=$1
   if [[ -n ${nixosSystem} ]]; then
     step Uploading the system closure
-    nixCopy --to "ssh://$sshConnection?remote-store=local?root=/mnt" "$nixosSystem"
+    nixCopy --to "ssh://$sshConnection?remote-store=local%3Froot=%2Fmnt" "$nixosSystem"
   elif [[ ${buildOn} == "remote" ]]; then
     step Building the system closure
     # We need to do a nix copy first because nix build doesn't have --no-check-sigs
     # Use ssh:// here to avoid https://github.com/NixOS/nix/issues/7359
-    nixCopy --to "ssh://$sshConnection?remote-store=local?root=/mnt" "${flake}#${flakeAttr}.system.build.toplevel" \
+    nixCopy --to "ssh://$sshConnection?remote-store=local%3Froot=%2Fmnt" "${flake}#${flakeAttr}.system.build.toplevel" \
       --derivation --no-check-sigs
     # If we don't use ssh-ng here, we get `error: operation 'getFSAccessor' is not supported by store`
     nixosSystem=$(
       nixBuild "${flake}#${flakeAttr}.system.build.toplevel" \
-        --eval-store auto --store "ssh-ng://$sshConnection?ssh-key=$sshKeyDir/nixos-anywhere&remote-store=local?root=/mnt"
+        --eval-store auto --store "ssh-ng://$sshConnection?ssh-key=$sshKeyDir%2Fnixos-anywhere&remote-store=local%3Froot=%2Fmnt"
     )
   fi
 


### PR DESCRIPTION
This flag allows users to run nixos-anywhere with [extra settings for SSH store](https://nix.dev/manual/nix/2.22/store/types/ssh-store), by appending it to ssh store url.

If a user has fast connection between client and target, but slow internet connection on target, the user can use `--no-substitute-on-destination` to copy closures from client instead of downloading it from internet. 

The copy speed (nix-copy to ssh store) can be greatly improved by enabling compression via `--ssh-store-settings "compress=true"`.

Existing url parameters (especially the special characters) need to be encoded to avoid unexpected results. Otherwise we will get something like `root` evaluates to `/mnt?compression=true`.