### PR TITLE
Re-invert behavior of --no-substitute-on-destination

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -123,6 +123,7 @@ step() {
 }
 
 parseArgs() {
+  local substituteOnDestination=y
   while [[ $# -gt 0 ]]; do
     case "$1" in
     -f | --flake)
@@ -226,7 +227,7 @@ parseArgs() {
       nixOptions+=("--option" "$key" "$value")
       ;;
     --no-substitute-on-destination)
-      nixCopyOptions+=("--substitute-on-destination")
+      substituteOnDestination=n
       ;;
     --build-on-remote)
       buildOnRemote=y
@@ -251,6 +252,10 @@ parseArgs() {
 
   if [[ ${printBuildLogs-n} == "y" ]]; then
     nixOptions+=("-L")
+  fi
+
+  if [[ $substituteOnDestination == "y" ]]; then
+    nixCopyOptions+=("--substitute-on-destination")
   fi
 
   if [[ $vmTest == "n" ]] && [[ -z ${sshConnection} ]]; then

--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -124,6 +124,7 @@ step() {
 
 parseArgs() {
   local substituteOnDestination=y
+  local printBuildLogs=n
   while [[ $# -gt 0 ]]; do
     case "$1" in
     -f | --flake)
@@ -250,7 +251,7 @@ parseArgs() {
     shift
   done
 
-  if [[ ${printBuildLogs-n} == "y" ]]; then
+  if [[ ${printBuildLogs} == "y" ]]; then
     nixOptions+=("-L")
   fi
 


### PR DESCRIPTION
Maybe there's a better way to do this, but it looks like removing elements from an array is kind of a pain.