### PR TITLE
terraform: fix typos in phase subtraction

### DIFF
--- a/terraform/install/main.tf
+++ b/terraform/install/main.tf
@@ -1,7 +1,7 @@
 locals {
   disk_encryption_key_scripts = [for k in var.disk_encryption_key_scripts : "\"${k.path}\" \"${k.script}\""]
   removed_phases =  setunion(var.stop_after_disko ? ["install"] : [], (var.no_reboot ? ["reboot"] : []))
-  phases = setsubstract(var.phases, removed_phases)
+  phases = setsubtract(var.phases, local.removed_phases)
   arguments = jsonencode({
     ssh_private_key = var.ssh_private_key
     debug_logging = var.debug_logging


### PR DESCRIPTION
This fixes the typos introduced by b699b3084dc8de18502ae0906eec67b4aaa7843c, which cause a Terraform semantic error.