### PR TITLE
Added stop_after_disko and no_reboot to script

### DIFF
--- a/terraform/install/main.tf
+++ b/terraform/install/main.tf
@@ -15,6 +15,8 @@ locals {
     extra_files_script = var.extra_files_script
     build_on_remote = var.build_on_remote
     flake = var.flake
+    stop_after_disko = var.stop_after_disko
+    no_reboot = var.no_reboot
     phases = join(",", local.phases)
   })
 }


### PR DESCRIPTION
This is fixing a bug when running the `run-nixos-anywhere.sh` script.

Fixes https://github.com/nix-community/nixos-anywhere/issues/389