### PR TITLE
nixos-anywhere: move unmount into `reboot` phase

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -73,7 +73,7 @@ Options:
   kexec: kexec into the nixos installer
   disko: first unmount and destroy all filesystems on the disks we want to format, then run the create and mount mode
   install: install the system
-  reboot: reboot the machine
+  reboot: unmount the filesystems, export any ZFS pools and reboot the machine
 * --disko-mode disko|mount|format
   set the disko mode to format, mount or destroy. Default is disko.
   disko: first unmount and destroy all filesystems on the disks we want to format, then run the create and mount mode


### PR DESCRIPTION
This means that users can now access the mounted filesystems by omitting the `reboot` phase.

You can combine this with `--disko-mode mount` to mount and upgrade an existing system before running `nixos-enter` to run commands on it.

    $ nixos-anywhere --disko-mode mount --phases kexec,disko,install

@Mic92 I wonder if it would be worth adding a separate `unmount` phase