### PR TITLE
terraform/nix-build.sh: prevent error on empty nix_options

### DIFF
--- a/terraform/nix-build/nix-build.sh
+++ b/terraform/nix-build/nix-build.sh
@@ -3,7 +3,11 @@ set -efu
 
 declare file attribute nix_options
 eval "$(jq -r '@sh "attribute=\(.attribute) file=\(.file) nix_options=\(.nix_options)"')"
-options=$(echo "${nix_options}" | jq -r '.options | to_entries | map("--option \(.key) \(.value)") | join(" ")')
+if [ "${nix_options}" != '{"options":{}}' ]; then
+  options=$(echo "${nix_options}" | jq -r '.options | to_entries | map("--option \(.key) \(.value)") | join(" ")')
+else
+  options=""
+fi
 if [[ -n ${file-} ]] && [[ -e ${file-} ]]; then
   # shellcheck disable=SC2086
   out=$(nix build --no-link --json $options -f "$file" "$attribute")


### PR DESCRIPTION
currently, when `var.nix_options` is not set, the jq map action yields `null`, which ends up missing up. using a conditional here, we may instead account for this case such as to set it to empty string and avoid the issue.