### PR TITLE
fix(disk-encryption-keys): ensure the target dir exists

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -529,7 +529,7 @@ runDisko() {
   local diskoScript=$1
   for path in "${!diskEncryptionKeys[@]}"; do
     step "Uploading ${diskEncryptionKeys[$path]} to $path"
-    runSsh "umask 077; cat > $path" <"${diskEncryptionKeys[$path]}"
+    runSsh "umask 077; mkdir -p \"$(dirname "$path")\"; cat > $path" <"${diskEncryptionKeys[$path]}"
   done
   if [[ -n ${diskoScript} ]]; then
     nixCopy --to "ssh://$sshConnection" "$diskoScript"


### PR DESCRIPTION
When using `--disk-encryption-keys`, copying will silently fail if the target file location's parent directory does not exist. 

This PR adds a `mkdir -p` to ensure that the target dir does exist.