### PR TITLE
hardware config: fix git add logic

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -176,7 +176,7 @@ parseArgs() {
         abort "Unknown hardware config backend: $2"
         ;;
       esac
-      hardwareConfigPath=$3
+      hardwareConfigPath="$(realpath "$3")"
       shift
       shift
       ;;
@@ -456,7 +456,9 @@ generateHardwareConfig() {
   # to make sure nix knows about the new file
   if command -v git >/dev/null; then
     pushd "$(dirname "$hardwareConfigPath")"
-    git add --intent-to-add --force -- "$hardwareConfigPath" >/dev/null 2>&1 || true
+    if git rev-parse --is-inside-work-tree >/dev/null; then
+      git add --intent-to-add --force -- "$hardwareConfigPath"
+    fi
     popd
   fi
 }


### PR DESCRIPTION
Fixing the git add hardware config logic in case the user provides a relative path. We're doing two things:

1. Failing loudly if the git add command fails. At that point, we already know git is in $PATH. If the git add fails, the evaluation will likely fail in a flake setting. Better fail early with a helpful git error message.
2. We're resolving the hardware config path in the CLI parsing layer to make sure this path has the meaning the user intented it to have.