### PR TITLE
nixos-anywhere: add --target-host option

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,12 +1,14 @@
 # CLI
 
 ```
-Usage: nixos-anywhere [options] <ssh-host>
+Usage: nixos-anywhere [options] [<ssh-host>]
 
 Options:
 
 * -f, --flake <flake_uri>
   set the flake to install the system from.
+* --target-host <ssh-host>
+  specified the SSH target host to deploy onto.
 * -i <identity_file>
   selects which SSH private key file to use.
 * -p, --ssh-port <ssh_port>

--- a/docs/howtos/disko-modes.md
+++ b/docs/howtos/disko-modes.md
@@ -10,7 +10,7 @@ To only mount existing filesystems, add `--disko-mode mount` to
 `nixos-anywhere`:
 
 ```
-nix run github:nix-community/nixos-anywhere -- --disko-mode mount --flake <path to configuration>#<configuration name> root@<ip address>
+nix run github:nix-community/nixos-anywhere -- --disko-mode mount --flake <path to configuration>#<configuration name> --target-host root@<ip address>
 ```
 
 1. This will first boot into a nixos-installer

--- a/docs/howtos/no-os.md
+++ b/docs/howtos/no-os.md
@@ -64,7 +64,7 @@ ssh -v nixos@fec0::5054:ff:fe12:3456
 You can then use the IP address to run `nixos-anywhere` like this:
 
 ```
-nix run github:nix-community/nixos-anywhere -- --flake '.#myconfig' nixos@fec0::5054:ff:fe12:3456
+nix run github:nix-community/nixos-anywhere -- --flake '.#myconfig' --target-host nixos@fec0::5054:ff:fe12:3456
 ```
 
 This example assumes a flake in the current directory containing a configuration

--- a/docs/howtos/secrets.md
+++ b/docs/howtos/secrets.md
@@ -35,7 +35,7 @@ pass ssh_host_ed25519_key > "$temp/etc/ssh/ssh_host_ed25519_key"
 chmod 600 "$temp/etc/ssh/ssh_host_ed25519_key"
 
 # Install NixOS to the host system with our secrets
-nixos-anywhere --extra-files "$temp" --flake '.#your-host' root@yourip
+nixos-anywhere --extra-files "$temp" --flake '.#your-host' --target-host root@yourip
 ```
 
 ## Example: Uploading Disk Encryption Secrets

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -217,7 +217,7 @@ You can now run **nixos-anywhere** from the command line as shown below, where:
 - `<ip address>` is the IP address of the target machine.
 
 ```
-nix run github:nix-community/nixos-anywhere -- --flake <path to configuration>#<configuration name> root@<ip address>
+nix run github:nix-community/nixos-anywhere -- --flake <path to configuration>#<configuration name> --target-host root@<ip address>
 ```
 
 The command would look  like this if you had created your files in a directory
@@ -225,20 +225,20 @@ named `/home/mydir/test` and the IP address of your target machine is
 `37.27.18.135`:
 
 ```
-nix run github:nix-community/nixos-anywhere -- --flake /home/mydir/test#hetzner-cloud root@37.27.18.135
+nix run github:nix-community/nixos-anywhere -- --flake /home/mydir/test#hetzner-cloud --target-host root@37.27.18.135
 ```
 
 If you also need to generate hardware configuration amend flags for
 nixos-generate-config:
 
 ```
-nix run github:nix-community/nixos-anywhere -- --generate-hardware-config nixos-generate-config ./hardware-configuration.nix --flake <path to configuration>#<configuration name> root@<ip address>
+nix run github:nix-community/nixos-anywhere -- --generate-hardware-config nixos-generate-config ./hardware-configuration.nix --flake <path to configuration>#<configuration name> --target-host root@<ip address>
 ```
 
 Or these flags if you are using nixos-facter instead:
 
 ```
-nix run github:nix-community/nixos-anywhere -- --generate-hardware-config nixos-facter ./facter.json  --flake <path to configuration>#<configuration name> root@<ip address>
+nix run github:nix-community/nixos-anywhere -- --generate-hardware-config nixos-facter ./facter.json  --flake <path to configuration>#<configuration name> --target-host root@<ip address>
 ```
 
 Adjust the location of `./hardware-configuration.nix` and `./facter.json`

--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -62,12 +62,14 @@ declare -a sshArgs=()
 
 showUsage() {
   cat <<USAGE
-Usage: nixos-anywhere [options] <ssh-host>
+Usage: nixos-anywhere [options] [<ssh-host>]
 
 Options:
 
 * -f, --flake <flake_uri>
   set the flake to install the system from.
+* --target-host <ssh-host>
+  specified the SSH target host to deploy onto.
 * -i <identity_file>
   selects which SSH private key file to use.
 * -p, --ssh-port <ssh_port>
@@ -141,6 +143,10 @@ parseArgs() {
     case "$1" in
     -f | --flake)
       flake=$2
+      shift
+      ;;
+    --target-host)
+      sshConnection=$2
       shift
       ;;
     -i)


### PR DESCRIPTION
Mirror the option from nixos-rebuild, so both have the same signature:

* Bootstrap: `nixos-anywhere --flake .#targethost --target-host root@1.2.3.4`

* Deploy: `nixos-rebuild --flake .#targethost --target-host root@1.2.3.4 switch`