### PR TITLE
Don't use sudo when uploading extraFiles

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -577,7 +577,7 @@ nixosInstall() {
 
   if [[ -n ${extraFiles} ]]; then
     step Copying extra files
-    tar -C "$extraFiles" -cpf- . | runSsh "${maybeSudo} tar -C /mnt -xf- --no-same-owner"
+    tar -C "$extraFiles" -cpf- . | runSsh "tar -C /mnt -xf- --no-same-owner"
     runSsh "chmod 755 /mnt" # tar also changes permissions of /mnt
   fi
 


### PR DESCRIPTION
There seems to be no scenario where we aren't root on the target system at this point.

But there is one where it breaks: If hasSudo is true because the pre-kexec env had it, but kexec env does not.

Fixes #431 