### PR TITLE
fix(nixos-generate-config): dont output carriage returns in output files

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -72,7 +72,7 @@ Options:
   Also supports variants:
   nixos-anywhere --flake .#nixosConfigurations.mymachine.config.virtualisation.vmVariant
 * --target-host <ssh-host>
-  specified the SSH target host to deploy onto.
+  set the SSH target host to deploy onto.
 * -i <identity_file>
   selects which SSH private key file to use.
 * -p, --ssh-port <ssh_port>
@@ -332,6 +332,9 @@ parseArgs() {
 }
 
 # ssh wrapper
+runSshNoTty() {
+  ssh -i "$sshKeyDir"/nixos-anywhere -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "${sshArgs[@]}" "$sshConnection" "$@"
+}
 runSshTimeout() {
   timeout 10 ssh -i "$sshKeyDir"/nixos-anywhere -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "${sshArgs[@]}" "$sshConnection" "$@"
 }
@@ -448,19 +451,18 @@ generateHardwareConfig() {
   nixos-facter)
     if [[ ${isInstaller} == "y" ]]; then
       if [[ ${hasNixOSFacter} == "n" ]]; then
-        abort "nixos-facter is not available in booted installer. You may want to boot an installer image from here instead: https://github.com/nix-community/nixos-images"
+        abort "nixos-facter is not available in booted installer, use nixos-generate-config. For nixos-facter, you may want to boot an installer image from here instead: https://github.com/nix-community/nixos-images"
       fi
     else
       maybeSudo=""
     fi
 
     step "Generating hardware-configuration.nix using nixos-facter"
-    # FIXME: if we take the output directly it adds some weird characters at the beginning
-    runSsh -o ConnectTimeout=10 ${maybeSudo} "nixos-facter" >"$hardwareConfigPath"
+    runSshNoTty -o ConnectTimeout=10 ${maybeSudo} "nixos-facter" >"$hardwareConfigPath"
     ;;
   nixos-generate-config)
     step "Generating hardware-configuration.nix using nixos-generate-config"
-    runSsh -o ConnectTimeout=10 nixos-generate-config --show-hardware-config --no-filesystems >"$hardwareConfigPath"
+    runSshNoTty -o ConnectTimeout=10 nixos-generate-config --show-hardware-config --no-filesystems >"$hardwareConfigPath"
     ;;
   *)
     abort "Unknown hardware config backend: $hardwareConfigBackend"


### PR DESCRIPTION
`ssh -t` is being used by `runSsh` which causes new lines in output designed for a terminal.  It could also output escape sequences.

https://unix.stackexchange.com/a/420438

this change fixes this problem (#438) by only outputting new lines.  but it might be worth removing ssh password entry as an option and the tty allocation, and force the use of sshpass for passwords.

There is a FIXME note regarding the output of the `nixos-facter` with _strange_ characters.  This may resolve that as well. 

Also updated the message about `nixos-facter` not being found to hopefully clarify and resolve #423 around the `--generate-hardware-config` option.