### PR TITLE
use installer for substituting

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -570,16 +570,16 @@ nixosInstall() {
   local nixosSystem=$1
   if [[ -n ${nixosSystem} ]]; then
     step Uploading the system closure
-    nixCopy --to "ssh://$sshConnection?remote-store=local?root=/mnt" "$nixosSystem"
+    nixCopy --substituters / --to "ssh://$sshConnection?remote-store=local?root=/mnt" "$nixosSystem"
   elif [[ ${buildOnRemote} == "y" ]]; then
     step Building the system closure
     # We need to do a nix copy first because nix build doesn't have --no-check-sigs
     # Use ssh:// here to avoid https://github.com/NixOS/nix/issues/7359
-    nixCopy --to "ssh://$sshConnection?remote-store=local?root=/mnt" "${flake}#${flakeAttr}.system.build.toplevel" \
+    nixCopy --substituters / --to "ssh://$sshConnection?remote-store=local?root=/mnt" "${flake}#${flakeAttr}.system.build.toplevel" \
       --derivation --no-check-sigs
     # If we don't use ssh-ng here, we get `error: operation 'getFSAccessor' is not supported by store`
     nixosSystem=$(
-      nixBuild "${flake}#${flakeAttr}.system.build.toplevel" \
+      nixBuild --substituters / "${flake}#${flakeAttr}.system.build.toplevel" \
         --eval-store auto --store "ssh-ng://$sshConnection?ssh-key=$sshKeyDir/nixos-anywhere&remote-store=local?root=/mnt"
     )
   fi


### PR DESCRIPTION
Also in most cases our installer will likely not be build from the same nixpkgs revision as our target system, this will still speed up things signifanctly when we don't have to upload drv files twice for `--build-on-remote`.
It might also help people that have their own installer build from the same nixpkgs revision as their target system.