### PR TITLE
Don't run preSwitchChecks during install

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -614,7 +614,7 @@ if [ ${copyHostKeys-n} = "y" ]; then
     cp -a "\$p" "/mnt/\$p"
   done
 fi
-nixos-install --no-root-passwd --no-channel-copy --system "$nixosSystem"
+NIXOS_NO_CHECK=1 nixos-install --no-root-passwd --no-channel-copy --system "$nixosSystem"
 if [[ ${phases[reboot]} == 1 ]]; then
   if command -v zpool >/dev/null && [ "\$(zpool list)" != "no pools available" ]; then
     # we always want to export the zfs pools so people can boot from it without force import


### PR DESCRIPTION
NixOS includes an option called `system.preSwitchChecks` since https://github.com/NixOS/nixpkgs/commit/6e192c4489ea44c48876faa11060798fb9502146.

As we are installing a new system here, we do not care too much about the systems state pre switching and therefore disable those checks. 

This change is motivated by https://github.com/nix-community/srvos/pull/591#issuecomment-2575221123

untested, but this might help @Kranzes?