### PR TITLE
Back out "Don't run preSwitchChecks during install"

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -719,7 +719,7 @@ if [ ${copyHostKeys-n} = "y" ]; then
     cp -a "\$p" "/mnt/\$p"
   done
 fi
-NIXOS_NO_CHECK=1 nixos-install --no-root-passwd --no-channel-copy --system "$nixosSystem"
+nixos-install --no-root-passwd --no-channel-copy --system "$nixosSystem"
 if [[ ${phases[reboot]} == 1 ]]; then
   if command -v zpool >/dev/null && [ "\$(zpool list)" != "no pools available" ]; then
     # we always want to export the zfs pools so people can boot from it without force import


### PR DESCRIPTION
This backs out commit be2d9d752660c95bb5232cd9829e150d05a90f25.

This backs out of #447

Now that https://github.com/nix-community/srvos/pull/591#issuecomment-2575221123 is fixed upstream, I think it would be preferable to run the pre-switch checks before installing to match the default behaviour of `nixos-install` and I usually think of `nixos-install` as `nixos-rebuild switch` with a few extra steps like installing a bootloader.