### PR TITLE
Allow skipping system.preSwitchChecks...

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -719,6 +719,10 @@ if [ ${copyHostKeys-n} = "y" ]; then
     cp -a "\$p" "/mnt/\$p"
   done
 fi
+# https://stackoverflow.com/a/13864829
+if [ ! -z ${NIXOS_NO_CHECK+0} ]; then
+  export NIXOS_NO_CHECK
+fi
 nixos-install --no-root-passwd --no-channel-copy --system "$nixosSystem"
 if [[ ${phases[reboot]} == 1 ]]; then
   if command -v zpool >/dev/null && [ "\$(zpool list)" != "no pools available" ]; then


### PR DESCRIPTION
as they might be written for switching from one generation to another, without initial installation in mind and failing checks would prevent successful installations.

This is a follow up on both #447 and #475, after a bit of discussion on matrix.
I still think that skipping those checks in nixos-install by default would have been a better default, but am not sure whether it's worth arguing about that upstream now.
The main reason is that it's at least possible to opt-out of preSwitchChecks with nixos-install in case a check is broken. This isn't possible with nixos-anywhere (before #447 and since #475), but will be after this PR. This is sufficient in order not to block installations in the presence of broken checks.

Trade-off is yet another obscure flag  ;)