### PR TITLE
feat: add a flag to reinstall the bootloader

### DIFF
--- a/terraform/all-in-one/main.tf
+++ b/terraform/all-in-one/main.tf
@@ -56,6 +56,7 @@ module "nixos-rebuild" {
   target_host = var.target_host
   target_user = var.target_user
   target_port = var.target_port
+  install_bootloader = var.install_bootloader
 }
 
 output "result" {

--- a/terraform/all-in-one/variables.tf
+++ b/terraform/all-in-one/variables.tf
@@ -143,3 +143,9 @@ variable "build_on_remote" {
   description = "Build the closure on the remote machine instead of building it locally and copying it over"
   default     = false
 }
+
+variable "install_bootloader" {
+  type = bool
+  description = "Install/re-install the bootloader"
+  default = false
+}

--- a/terraform/nixos-rebuild/main.tf
+++ b/terraform/nixos-rebuild/main.tf
@@ -6,6 +6,6 @@ resource "null_resource" "nixos-rebuild" {
     environment = {
       SSH_KEY = var.ssh_private_key
     }
-    command = "${path.module}/deploy.sh ${var.nixos_system} ${var.target_user} ${var.target_host} ${var.target_port} ${var.ignore_systemd_errors}"
+    command = "${path.module}/deploy.sh ${var.nixos_system} ${var.target_user} ${var.target_host} ${var.target_port} ${var.ignore_systemd_errors} ${var.install_bootloader}"
   }
 }

--- a/terraform/nixos-rebuild/variables.tf
+++ b/terraform/nixos-rebuild/variables.tf
@@ -31,3 +31,9 @@ variable "ignore_systemd_errors" {
   description = "Ignore systemd errors happening during deploy"
   default = false
 }
+
+variable "install_bootloader" {
+  type = bool
+  description = "Install/re-install the bootloader"
+  default = false
+}


### PR DESCRIPTION
Without this, it isn't possible to for instance migrate from grub to systemd-boot, since there is no way to pass the flag to install the bootloader.
