### PR TITLE
Don't create/chmod `/mnt/tmp` unless necessary

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -722,9 +722,12 @@ set -eu ${enableDebug}
 # when running not in nixos we might miss this directory, but it's needed in the nixos chroot during installation
 export PATH="\$PATH:/run/current-system/sw/bin"
 
-# needed for installation if initrd-secrets are used
-mkdir -p /mnt/tmp
-chmod 777 /mnt/tmp
+if [ ! -d "/mnt/tmp" ]; then
+  # needed for installation if initrd-secrets are used
+  mkdir -p /mnt/tmp
+  chmod 777 /mnt/tmp
+fi
+
 if [ ${copyHostKeys-n} = "y" ]; then
   # NB we copy host keys that are in turn copied by kexec installer.
   mkdir -m 755 -p /mnt/etc/ssh


### PR DESCRIPTION
When running `nixos-install` with a read-only root filesystem (e.g. set via Disko's `nodev` option), the following error occurs and installation is halted:

```
### Installing NixOS ###
Pseudo-terminal will not be allocated because stdin is not a terminal.
chmod: changing permissions of '/mnt/tmp': Read-only file system
```

This PR fixes the error by only running the `chmod` (and `mkdir`) logic when `/mnt/tmp` doesn't exist.