### PR TITLE
add missing --wait to setsid

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -638,7 +638,7 @@ set -eu ${enableDebug}
 ${maybeSudo} rm -rf /root/kexec
 ${maybeSudo} mkdir -p /root/kexec
 %TAR_COMMAND%
-TMPDIR=/root/kexec setsid sudo /root/kexec/kexec/run --kexec-extra-flags \"$kexecExtraFlags\"
+TMPDIR=/root/kexec setsid --wait sudo /root/kexec/kexec/run --kexec-extra-flags \"$kexecExtraFlags\"
 "
 
   # Define upload commands


### PR DESCRIPTION
Credits by Nicolas D.

#527 modified the `nixos-anywhere.sh` behavior in the following manner:

1. The shell snippet used to run `/root/kexec/kexec/run` went from being passed over `stdin`, through the use of a here document, to being passed as a command line argument.
2. As a result, the `ssh -t` invocation went from not allocating a pseudo TTY to allocating one.
3. The presence of the pseudo TTY changed the behavior of `setsid` from `--wait` to `--fork`.
4. In the `--fork` mode ,`setsid` does not setup `stdout` for `/root/kexec/kexec/run`.
5. As a result, `/root/kexec/kexec/run` does not run the `kexec` step; it dies on [the `echo "machine will boot into nixos in 6s..."` line](https://github.com/nix-community/nixos-images/blob/191a461dc38313ff41bd3df4b82e49f74a56560d/nix/kexec-installer/kexec-run.sh#L99).
6. In `--fork` mode, `setsid` does not propagate the error condition upwards, so `nixos-anywhere.sh` is not notified of the issue.
7. `nixos-anywhere.sh` waits forever for a reboot that will never happen.