### PR TITLE
Preserve SSH options when switching to the root user

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -839,7 +839,7 @@ main() {
 
   sshSettings=$(ssh "${sshArgs[@]}" -G "${sshConnection}")
   sshUser=$(echo "$sshSettings" | awk '/^user / { print $2 }')
-  sshHost=$(echo "$sshSettings" | awk '/^hostname / { print $2 }')
+  sshHost=$(echo "$sshSettings" | awk '/^host / { print $2 }')
 
   uploadSshKey
 


### PR DESCRIPTION
After kexec or if the remote host is already running a nixOS installer, we need to change the ssh user to root to proceed with the installation.

In the current implementation, we compute the ssh settings from the provided ssh connection string, extract the hostname option and rewrite the connection string as `root@hostname`.

There are two similar fields in an ssh config:
 * hostname: the real ip/fqdn of the host
 * host: the user configured alias for the host
 
 For hosts with no configuration, host and hostname have the same value

```bash
ssh -G foo@some-unkown-server | grep -E '^(user|hostname|host|proxyjump)\s'
host some-unkown-server
user foo
hostname some-unkown-server
```

But if the host has an alias in the ssh config, the two fields can differ
```
Host server
  HostName 1.2.3.4
  ProxyJump jumphost
  User cloud
```
```bash
ssh -G server | grep -E '^(user|hostname|host|proxyjump)\s'
host server
user foo
hostname 1.2.3.4
proxyjump jumphost
```

If nixos-anywhere is called with `server`, when switching to root, we'll try to connect as `root@1.2.3.4`, losing the jumphost configuration.

```bash
ssh -G root@1.2.3.4 | grep -E '^(user|hostname|host|proxyjump)\s'
host 1.2.3.4
user root
hostname 1.2.3.4
```

By using the `host` field instead of the `hostname` field, we keep the user's configuration when switching to root, we preserve those options.

```bash
ssh -G root@server | grep -E '^(user|hostname|host|proxyjump)\s'
host server
user root
hostname 1.2.3.4
proxyjump jumphost
```