### PR TITLE
Fix order of passing `nixOptions` in `nixos-facter call`

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -586,7 +586,7 @@ generateHardwareConfig() {
     fi
     if [[ ${hasNixOSFacter} == "n" ]]; then
       step "Generating facter.json using nixos-facter from nixpkgs"
-      runSshNoTty -o ConnectTimeout=10 "${maybeSudo}" \
+      runSshNoTty -o ConnectTimeout=10 \
         nix run "${nixOptions[@]}" \
         nixpkgs#nixos-facter >"$hardwareConfigPath"
     else

--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -587,8 +587,7 @@ generateHardwareConfig() {
     if [[ ${hasNixOSFacter} == "n" ]]; then
       step "Generating facter.json using nixos-facter from nixpkgs"
       runSshNoTty -o ConnectTimeout=10 \
-        nix run "${nixOptions[@]}" \
-        nixpkgs#nixos-facter >"$hardwareConfigPath"
+        nix run nixpkgs#nixos-facter "${nixOptions[@]}" >"$hardwareConfigPath"
     else
       step "Generating facter.json using nixos-facter"
       runSshNoTty -o ConnectTimeout=10 "${maybeSudo}" "nixos-facter" >"$hardwareConfigPath"


### PR DESCRIPTION
This fixes an issue where the 2nd argument of
`--extra-experimental-features` is parsed as a flake, instead of the
argument to the flag