### PR TITLE
 nixos-anywhere: fix running `nixos-facter` when it isn't installed

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -586,7 +586,7 @@ generateHardwareConfig() {
     fi
     if [[ ${hasNixOSFacter} == "n" ]]; then
       step "Generating facter.json using nixos-facter from nixpkgs"
-      runSshNoTty -o ConnectTimeout=10 \
+      runSshNoTty -o ConnectTimeout=10 "${maybeSudo}" \
         nix run "${nixOptions[@]}" \
         nixpkgs#nixos-facter >"$hardwareConfigPath"
     else

--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -581,9 +581,6 @@ generateHardwareConfig() {
   mkdir -p "$(dirname "$hardwareConfigPath")"
   case "$hardwareConfigBackend" in
   nixos-facter)
-    if [[ ${isInstaller} == "y" ]]; then
-      maybeSudo=""
-    fi
     if [[ ${hasNixOSFacter} == "n" ]]; then
       step "Generating facter.json using nixos-facter from nixpkgs"
 
@@ -703,6 +700,9 @@ TMPDIR=/root/kexec setsid --wait ${maybeSudo} /root/kexec/kexec/run --kexec-extr
 
   # After kexec we explicitly set the user to root@
   sshConnection="root@${sshHost}"
+
+  # TODO: remove this after we reimport facts post-kexec and set this as a fact
+  maybeSudo=""
 
   # waiting for machine to become available again
   until runSsh -o ConnectTimeout=10 -- exit 0; do sleep 5; done

--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -587,7 +587,8 @@ generateHardwareConfig() {
     if [[ ${hasNixOSFacter} == "n" ]]; then
       step "Generating facter.json using nixos-facter from nixpkgs"
       runSshNoTty -o ConnectTimeout=10 \
-        nix run nixpkgs#nixos-facter "${nixOptions[@]}" >"$hardwareConfigPath"
+        nix run "${nixOptions[@]}" \
+        nixpkgs#nixos-facter >"$hardwareConfigPath"
     else
       step "Generating facter.json using nixos-facter"
       runSshNoTty -o ConnectTimeout=10 "${maybeSudo}" "nixos-facter" >"$hardwareConfigPath"

--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -586,12 +586,12 @@ generateHardwareConfig() {
     fi
     if [[ ${hasNixOSFacter} == "n" ]]; then
       step "Generating facter.json using nixos-facter from nixpkgs"
-      runSshNoTty -o ConnectTimeout=10 "${maybeSudo}" \
+      runSshNoTty -o ConnectTimeout=10 ${maybeSudo} \
         nix run "${nixOptions[@]}" \
         nixpkgs#nixos-facter >"$hardwareConfigPath"
     else
       step "Generating facter.json using nixos-facter"
-      runSshNoTty -o ConnectTimeout=10 "${maybeSudo}" "nixos-facter" >"$hardwareConfigPath"
+      runSshNoTty -o ConnectTimeout=10 ${maybeSudo} nixos-facter >"$hardwareConfigPath"
     fi
     ;;
   nixos-generate-config)


### PR DESCRIPTION
This PR reverts #570 as I think we still want to run `nixos-facter` with `sudo` if possible and the changing the order of the flags doesn't fix the quoting issues