### PR TITLE
nixos-anywhere: Fix installer check for nixos-facter invocation

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -581,7 +581,7 @@ generateHardwareConfig() {
   mkdir -p "$(dirname "$hardwareConfigPath")"
   case "$hardwareConfigBackend" in
   nixos-facter)
-    if [[ ${isInstaller} == "y" ]]; then
+    if [[ ${isInstaller} == "n" ]]; then
       maybeSudo=""
     fi
     if [[ ${hasNixOSFacter} == "n" ]]; then


### PR DESCRIPTION
If we are not running in an installer we can't predict if
the system actually has access to sudo.
So we fall back to the non-sudo `nixos-facter` report.
