### PR TITLE
Fully detach backgrounded reboot to prevent hanging SSH session

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -789,7 +789,7 @@ nixosReboot() {
     swapoff -a
     zpool export -a || true
   fi
-  nohup sh -c 'sleep 6 && reboot' >/dev/null &
+  nohup sh -c 'sleep 6 && reboot' >/dev/null 2>&1 &
 SSH
 
   step Waiting for the machine to become unreachable due to reboot


### PR DESCRIPTION
This PR ensures that the backgrounded reboot command is fully detached, preventing SSH from occasionally hanging after the command is sent. By redirecting both stdout and stderr, the ssh session can close cleanly without waiting on open channels. This project is really cool and I hope to contribute a small improvement.