### PR TITLE
Release 1.12.0

### DIFF
--- a/src/default.nix
+++ b/src/default.nix
@@ -33,7 +33,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "nixos-anywhere";
-  version = "1.11.0";
+  version = "1.12.0";
   src = ./..;
   nativeBuildInputs = [ makeWrapper ];
   installPhase = ''


### PR DESCRIPTION
Release 1.12.0 of nixos-anywhere

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped application/package version to 1.12.0 to reflect the latest stable release. This update does not introduce new features, bug fixes, or behavioral changes. Dependencies, install process, and metadata remain the same. Users should not observe any differences; no action is required beyond updating to receive the new version tag. Minor housekeeping only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->