### PR TITLE
change from-nixos-with-sudo.nix to interactive sudo-with-password test

### DIFF
--- a/tests/from-nixos-with-sudo.nix
+++ b/tests/from-nixos-with-sudo.nix
@@ -8,33 +8,40 @@
 
       users.users.nixos = {
         isNormalUser = true;
+        password = "somespecialpassword";
         openssh.authorizedKeys.keyFiles = [ ./modules/ssh-keys/ssh.pub ];
         extraGroups = [ "wheel" ];
       };
       security.sudo.enable = true;
-      security.sudo.wheelNeedsPassword = false;
+      security.sudo.wheelNeedsPassword = true;
     };
   };
-  testScript = ''
-    start_all()
-    installer.succeed("echo super-secret > /tmp/disk-1.key")
-    output = installer.succeed("""
-      nixos-anywhere \
-        -i /root/.ssh/install_key \
-        --debug \
-        --kexec /etc/nixos-anywhere/kexec-installer.tar.gz \
-        --phases kexec,disko \
-        --disk-encryption-keys /tmp/disk-1.key /tmp/disk-1.key \
-        --disk-encryption-keys /tmp/disk-2.key <(echo another-secret) \
-        --store-paths /etc/nixos-anywhere/disko /etc/nixos-anywhere/system-to-install \
-        nixos@installed >&2
-      echo "disk-1.key: '$(ssh -i /root/.ssh/install_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-        root@installed cat /tmp/disk-1.key)'"
-      echo "disk-2.key: '$(ssh -i /root/.ssh/install_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-        root@installed cat /tmp/disk-2.key)'"
-    """)
 
-    assert "disk-1.key: 'super-secret'" in output, f"output does not contain expected values: {output}"
-    assert "disk-2.key: 'another-secret'" in output, f"output does not contain expected values: {output}"
-  '';
+  testScript =
+    { nodes, ... }:
+    ''
+      start_all()
+
+      installer.succeed("echo super-secret > /tmp/disk-1.key")
+      installer.wait_for_unit("getty.target")
+      installer.wait_for_unit("multi-user.target")
+      installer.wait_for_unit("default.target")
+
+      installer.wait_until_tty_matches("1",".*root.installer:.*")
+      command="nixos-anywhere -i /root/.ssh/install_key --debug --kexec /etc/nixos-anywhere/kexec-installer.tar.gz --phases kexec,disko --disk-encryption-keys /tmp/disk-1.key /tmp/disk-1.key --disk-encryption-keys /tmp/disk-2.key <(echo another-secret) --store-paths /etc/nixos-anywhere/disko /etc/nixos-anywhere/system-to-install nixos@installed\n"
+      installer.send_chars(command)
+
+
+      installer.wait_until_tty_matches("1",".* password for nixos:.*")
+      installer.send_chars("${nodes.installed.users.users.nixos.password}\n")
+
+      installer.wait_until_tty_matches("1",".*### Done! ###.*")
+      installer.wait_until_tty_matches("1",".*root.installer:.*")
+
+      output = installer.succeed("""echo "disk-1.key: '$(ssh -i /root/.ssh/install_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@installed cat /tmp/disk-1.key)'" """)
+      assert "disk-1.key: 'super-secret'" in output, f"output does not contain expected values: {output}"
+
+      output = installer.succeed("""echo "disk-2.key: '$(ssh -i /root/.ssh/install_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@installed cat /tmp/disk-2.key)'" """)
+      assert "disk-2.key: 'another-secret'" in output, f"output does not contain expected values: {output}"
+    '';
 }

--- a/tests/modules/installer.nix
+++ b/tests/modules/installer.nix
@@ -1,11 +1,12 @@
-{ pkgs, inputs, ... }:
+{ pkgs, inputs, lib, ... }:
 {
   system.activationScripts.rsa-key = ''
     ${pkgs.coreutils}/bin/install -D -m600 ${./ssh-keys/ssh} /root/.ssh/install_key
   '';
 
   environment.systemPackages = [ inputs.nixos-anywhere ];
-
+  services.getty.autologinUser = lib.mkForce "root";
+  console.earlySetup = true;
   environment.etc = {
     "nixos-anywhere/disko".source = inputs.system-to-install.config.system.build.diskoScriptNoDeps;
     "nixos-anywhere/system-to-install".source = inputs.system-to-install.config.system.build.toplevel;


### PR DESCRIPTION
This changes the passwordless sudo test to an interactive sudo test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated scenarios to require a sudo password and provide a user password to better reflect secured environments.
  * Refactored the test script definition to a new, more structured format for invocation and interaction.
  * Adjusted installer test environment to enable root autologin and early console initialization for smoother test execution.
* **Style**
  * Performed minor formatting cleanup in test modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->