### PR TITLE
Move kexec CLI checks inside the kexec branch

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -983,23 +983,23 @@ main() {
 
   importFacts
 
-  if [[ ${hasTar-n} == "n" ]]; then
-    abort "no tar command found, but required to unpack kexec tarball"
-  fi
-
-  if [[ ${hasCpio-n} == "n" ]]; then
-    abort "no cpio command found, but required to build the new initrd"
-  fi
-
-  if [[ ${hasSetsid-n} == "n" ]]; then
-    abort "no setsid command respecting --wait found, but required to run the kexec script under a new session"
-  fi
-
   if [[ ${isOs} != "Linux" ]]; then
     abort "This script requires Linux as the operating system, but got $isOs"
   fi
 
   if [[ ${phases[kexec]} == 1 ]]; then
+    if [[ ${hasTar-n} == "n" ]]; then
+      abort "no tar command found, but required to unpack kexec tarball"
+    fi
+
+    if [[ ${hasCpio-n} == "n" ]]; then
+      abort "no cpio command found, but required to build the new initrd"
+    fi
+
+    if [[ ${hasSetsid-n} == "n" ]]; then
+      abort "no setsid command respecting --wait found, but required to run the kexec script under a new session"
+    fi
+
     runKexec
   fi
 


### PR DESCRIPTION
I tried these changes inside a very minimal kexec env that I already booted into, where CLIs that are used to run kexec are not needed, and it can install without failing.