### PR TITLE
docs: avoid trailing newline in disk-encryption keyfile example

### DIFF
--- a/docs/howtos/secrets.md
+++ b/docs/howtos/secrets.md
@@ -47,7 +47,7 @@ to `nixos-anywhere`:
 
 ```bash
 # Write your disk encryption password to a file
-echo "my-super-safe-password" > /tmp/disk-1.key
+printf '%s' "my-super-safe-password" > /tmp/disk-1.key
 
 # Call nixos-anywhere with disk encryption keys
 nixos-anywhere \


### PR DESCRIPTION
Closes #689

## What

`docs/howtos/secrets.md`'s disk-encryption example writes the keyfile with
plain `echo`, which appends a trailing newline:

```bash
echo "my-super-safe-password" > /tmp/disk-1.key
```

This is harmless for the documented flow, since disko reads `passwordFile`
via `$(cat ...)` (which strips trailing newlines), so `luksFormat` gets the
intended password regardless. But it's a footgun if the same keyfile is
later read raw with `cryptsetup --key-file`, e.g. `luksChangeKey` to swap a
bootstrap key for a real passphrase after install. That reads exact bytes
with no stripping, so it silently authenticates against
`my-super-safe-password\n` and needs an explicit `--keyfile-size <N-1>` to
work around it. Nothing errors, it just fails in a confusing way.

This swaps `echo` for `printf '%s'`, so the keyfile's bytes are exactly the
intended secret regardless of how it gets read later.

## Testing

Documentation-only change (one line), no code/build affected.

Marking this AI-assisted: this PR was authored by an AI coding agent
(Claude).
